### PR TITLE
Fix sitemap generation

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,7 +22,6 @@ module.exports = {
   siteMetadata: siteMetadata,
 
   plugins: [
-    "gatsby-plugin-sitemap",
     "gatsby-plugin-eslint",
     "gatsby-plugin-no-sourcemaps",
     "gatsby-plugin-react-helmet",
@@ -32,6 +31,14 @@ module.exports = {
 
     // Sets page.updatedAt to the author time of last commit (https://git.io/JfPCj)
     "saber-plugin-git-modification-time",
+
+    // Custom sitemap configuration that fixes prefix issues
+    {
+      resolve: `gatsby-plugin-sitemap`,
+      options: {
+        resolveSiteUrl: () => new URL(siteMetadata.siteUrl).origin,
+      },
+    },
 
     // Prevent nav from (un)mounting on page navigations (https://git.io/JfOKn)
     {


### PR DESCRIPTION
The sitemap plugin is generating base URLs that contain the site prefix, causing URLs in the sitemap with double prefixes (`/workers/workers/platform`). This change removes the extra prefix by resolving the site URL in `gatsby-plugin-sitemap` to contain just the origin.

When building docs using this change, `sitemap.xml` correctly outputs the right URLs:

```xml
<url><loc>http://developers.cloudflare.com/pages/</loc> <changefreq>daily</changefreq><priority>0.7</priority></url>
<url><loc>http://developers.cloudflare.com/pages/platform/build-configuration</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
<url><loc>http://developers.cloudflare.com/pages/platform/github-integration</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
```

Closes #289