### PR TITLE
Add robots.txt for workers.dev docs deploys

### DIFF
--- a/bin/postbuild.js
+++ b/bin/postbuild.js
@@ -30,6 +30,8 @@ const handleExec = (completed) => {
   }
 }
 
+const robots = `User-agent: *\nDisallow: /`
+
 if (pathPrefix !== "") {
   // We are running from inside `.docs/`
   const dir = "$PWD/"
@@ -39,6 +41,9 @@ if (pathPrefix !== "") {
     exec(`mkdir "${dir}public"`, handleExec(() => {
       exec(`mv "${dir}${folderName}" "${dir}public/"`, handleExec(() => {
         console.log("Completed postbuild")
+        if (process.env.WORKERS_ENV && process.env.WORKERS_ENV === "development") {
+          fs.writeFile(`${process.env.PWD}/public/robots.txt`, robots, err => err && console.error(err))
+        }
       }))
     }))
   }))

--- a/bin/postbuild.js
+++ b/bin/postbuild.js
@@ -42,6 +42,7 @@ if (pathPrefix !== "") {
       exec(`mv "${dir}${folderName}" "${dir}public/"`, handleExec(() => {
         console.log("Completed postbuild")
         if (process.env.WORKERS_ENV && process.env.WORKERS_ENV === "development") {
+          console.log("Building robots.txt for development environment")
           fs.writeFile(`${process.env.PWD}/public/robots.txt`, robots, err => err && console.error(err))
         }
       }))


### PR DESCRIPTION
When WORKERS_ENV is set to `development`, a robots.txt file blocking all crawling of the site will be written to `public/robots.txt`.

When this is merged, we'll need to do a corresponding update to cloudflare/cloudflare-docs to set WORKERS_ENV to development for any deploys not going to production