### PR TITLE
Add Google Analytics Proxy to the docs engine

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import googleAnalytics from './utils/google-analytics'
 
 export default function HTML(props) {
   return (
@@ -9,6 +10,8 @@ export default function HTML(props) {
         <meta httpEquiv="x-ua-compatible" content="ie=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         { props.headComponents }
+        <script type="text/javascript" src="/_cf/analytics.js" />
+        <script type="text/javascript" dangerouslySetInnerHTML={{ __html: googleAnalytics }}/>
       </head>
 
       <body { ...props.bodyAttributes }>

--- a/src/utils/google-analytics.js
+++ b/src/utils/google-analytics.js
@@ -1,0 +1,19 @@
+export default `const GA_ID = "UA-107218623-2"
+window.ga =
+  window.ga ||
+  function () {
+    if (!GA_ID) {
+      return
+    }
+    ;(ga.q = ga.q || []).push(arguments)
+  }
+ga.l = +new Date()
+ga('create', GA_ID, 'auto')
+ga('set', 'transport', 'beacon')
+var timeout = setTimeout(
+  (onload = function () {
+    clearTimeout(timeout)
+    ga('send', 'pageview')
+  }),
+  1000,
+)`

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,4 +1,5 @@
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
+import analytics from 'workers-google-analytics'
 import redirector from 'lilredirector'
 
 const docsConfig = require("../docs-config.js")
@@ -43,6 +44,11 @@ async function handleEvent(event) {
       validateRedirects: false
     })
     if (response) return response
+
+    const analyticsResp = await analytics(event, {
+      allowList: ['developers.cloudflare.com'],
+    })
+    if (analyticsResp) return analyticsResp
 
     if (DEBUG) {
       // customize caching

--- a/workers-site/package-lock.json
+++ b/workers-site/package-lock.json
@@ -79,6 +79,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "workers-google-analytics": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/workers-google-analytics/-/workers-google-analytics-0.0.3.tgz",
+      "integrity": "sha512-R17b/uKw8jw9oq0nucIildywrJ4QsEpcQss5XHzpp9POCZxKs+/uIpJtuOQjjB1Vw9gTXotwkgtbqiorqu1MPg==",
+      "requires": {
+        "@cloudflare/workers-types": "^2.0.0"
+      }
     }
   }
 }

--- a/workers-site/package.json
+++ b/workers-site/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.0.12",
-    "lilredirector": "^0.5.1"
+    "lilredirector": "^0.5.1",
+    "workers-google-analytics": "0.0.3"
   }
 }


### PR DESCRIPTION
- Add workers-google-analytics to Worker

This commit adds the [workers-google-analytics](https://github.com/cloudflare/workers-google-analytics) package to the Workers application for each docs site, and uses the `.cloudflare/ga` route to proxy requests to Google Analytics.

- Add Google Analytics script to Gatsby component

This commit also adds the Google Analytics script to the Gatsby components for the docs engine, which will load the modified Google Analytics script and begin making requests to the local `.cloudflare/ga` endpoint mentioned above.