### PR TITLE
Alias vue syntax highlighting to HTML

### DIFF
--- a/src/components/mdx/custom-syntax-highlighting.js
+++ b/src/components/mdx/custom-syntax-highlighting.js
@@ -1,7 +1,8 @@
 export const languageMappings = {
   "shell": "sh",
   "javascript": "js",
-  "markup": "html"
+  "markup": "html",
+  "vue": "html"
 }
 
 export const prismLanguages = {


### PR DESCRIPTION
Prism doesn't have Vue SFC syntax highlighting (https://github.com/PrismJS/prism/issues/1665) so we should alias it to the `html` syntax for the near future