### PR TITLE
feat: forward arguments to npm commands

### DIFF
--- a/bin/commands.sh
+++ b/bin/commands.sh
@@ -92,7 +92,7 @@ if [ "$1" = "develop" ]; then
   npm run clean
 
   echo "Running npm run develop"
-  npm run develop
+  npm run develop -- "${@:2}"
 fi
 
 
@@ -105,7 +105,7 @@ if [ "$1" = "build" ]; then
   cd .docs
 
   echo "Running npm run build"
-  npm run build
+  npm run build -- "${@:2}"
 
   # We must run from inside `.docs/`
   echo "Running bin/postbuild.js"
@@ -120,7 +120,7 @@ if [ "$1" = "serve" ]; then
   cd .docs
 
   echo "Running npm run serve"
-  npm run serve
+  npm run serve -- "${@:2}"
 fi
 
 


### PR DESCRIPTION
Hi! 👋🏽 

This PR adds support for forwarding the arguments provided to a command, skipping the first - the actual command.

With this change, one can now provide a custom port to the `npm run develop` command, for example, with:

`npm run develop -- -p 4000` <- same way as without `commands.sh`.

If no arguments are provided (`npm run develop`), the behaviour will be the same as it is today.