### PR TITLE
Add "rules" to products array in gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,7 @@ const products = [
   "network-interconnect",
   "randomness-beacon",
   "registrar",
+  "rules",
   "spectrum",
   "ssl",
   "stream",


### PR DESCRIPTION
Even though the Rules icon is already available in the `cloudflare-brand-assets` repository, we're still missing a `rules` entry here in the `products` array.