### PR TITLE
added 4 different size images to be used in docs

### DIFF
--- a/src/css/docs/components/docs-markdown.css
+++ b/src/css/docs/components/docs-markdown.css
@@ -14,6 +14,22 @@
   overflow: visible;
 }
 
+.DocsMarkdown .small-img {
+  max-width:242px;
+}
+
+.DocsMarkdown .medium-img {
+  max-width:311px;
+}
+
+.DocsMarkdown .large-img {
+  max-width:450px;
+}
+
+.DocsMarkdown .full-img {
+  max-width:692px;
+}
+
 .DocsMarkdown--link {
   text-decoration: none;
   color: inherit;


### PR DESCRIPTION
4 new sizes based on the recommendation of John Adams on the UX Design team: 
1.Small: 242px
2.Medium: 311px
3.Large: 450px
4.Full: 692px

Need to wrap the image in a div with the correct classnames and put the image in a img element in the markdown for product

<img width="469" alt="Screen Shot 2021-04-23 at 12 50 27 PM" src="https://user-images.githubusercontent.com/19618017/115911268-7ea59400-a433-11eb-9792-3fe841516007.png">

Here are a few examples of the images being rendered on a desktop:

<img width="721" alt="Screen Shot 2021-04-23 at 12 50 51 PM" src="https://user-images.githubusercontent.com/19618017/115911388-a39a0700-a433-11eb-86b7-978d2d2105a2.png">

<img width="841" alt="Screen Shot 2021-04-23 at 12 50 58 PM" src="https://user-images.githubusercontent.com/19618017/115911486-c2989900-a433-11eb-9da2-29e67f0d7642.png">


On a mobile device:

<img width="354" alt="Screen Shot 2021-04-23 at 12 52 24 PM" src="https://user-images.githubusercontent.com/19618017/115911456-bb718b00-a433-11eb-89ea-83a21148a27f.png">

<img width="417" alt="Screen Shot 2021-04-23 at 1 00 35 PM" src="https://user-images.githubusercontent.com/19618017/115911611-ebb92980-a433-11eb-9b9f-a0892948b72c.png">
