### PR TITLE
Add bottom margin (same as P) to new resized image classes

### DIFF
--- a/src/css/docs/components/docs-markdown.css
+++ b/src/css/docs/components/docs-markdown.css
@@ -16,18 +16,22 @@
 
 .DocsMarkdown .small-img {
   max-width:242px;
+  margin-bottom: 1em;  
 }
 
 .DocsMarkdown .medium-img {
   max-width:311px;
+  margin-bottom: 1em;
 }
 
 .DocsMarkdown .large-img {
   max-width:450px;
+  margin-bottom: 1em;
 }
 
 .DocsMarkdown .full-img {
   max-width:692px;
+  margin-bottom: 1em;
 }
 
 .DocsMarkdown--link {


### PR DESCRIPTION
We'll be using images in isolated DIVs with the new classes. These classes don't have an assigned bottom margin.
Adding the same bottom margin value that paragraphs have (`1em`).

Before vs. After:

![image](https://user-images.githubusercontent.com/680496/118255011-a07abf80-b4a3-11eb-93d2-3293868e4e07.png)

Cc: @gganch 