### PR TITLE
Use first heading for page title instead of frontmatter field

### DIFF
--- a/src/components/docs-page.js
+++ b/src/components/docs-page.js
@@ -27,7 +27,7 @@ import getTableOfContents from "../utils/get-table-of-contents"
 import hasBreadcrumbs from "../utils/has-breadcrumbs"
 
 const DocsPage = ({ pageContext: page, children, location }) => {
-  const title = getPageTitle(page)
+  const title = getPageTitle(page, true)
   const pageType = getPageType(page)
   const tableOfContents = getTableOfContents(page)
 

--- a/src/utils/get-page-title.js
+++ b/src/utils/get-page-title.js
@@ -1,5 +1,9 @@
-export default ({ frontmatter, headings }) => {
+export default ({ frontmatter, headings }, useHeading=false) => {
   if (!frontmatter) return "Not found"
+
+  if (useHeading) {
+    return (headings.length && headings[0].value) || frontmatter.title
+  }
 
   return frontmatter.title || (headings.length && headings[0].value)
 }


### PR DESCRIPTION
The first heading of a documentation topic, when different from the frontmatter `title` field, is usually more complete and should be used in the page `<title>` (and other SEO-related meta fields) for SEO purposes.

Changing the behavior of `get-page-field` so that you can ask it to prefer the first heading, and only use the frontmatter entry if no heading is available. The new behavior only affects the content rendered by the `SEO` component.