### PR TITLE
fixed issue on firefox where anchor scrolling did not go to correct a…

### DIFF
--- a/src/components/docs-table-of-contents.js
+++ b/src/components/docs-table-of-contents.js
@@ -1,22 +1,9 @@
 import React from "react"
 
-import { navigate } from "@reach/router"
-
 class Item extends React.Component {
 
   constructor(props) {
     super(props)
-
-    this.handleLinkClick = this.handleLinkClick.bind(this)
-  }
-
-  handleLinkClick(event) {
-    // If we don’t handle this click, then the page
-    // will hard refresh for the "↑ Top" item, and
-    // if we use <Link/>, @reach throws an error:
-    // https://github.com/reach/router/issues/114
-    event.preventDefault()
-    navigate(event.target.href)
   }
 
   render() {
@@ -24,7 +11,7 @@ class Item extends React.Component {
 
     return (
       <li key={item.url}>
-        <a className="DocsTableOfContents-link" href={item.url} onClick={this.handleLinkClick}>
+        <a className="DocsTableOfContents-link" href={item.url}>
           {item.title}
         </a>
 
@@ -42,7 +29,8 @@ class Item extends React.Component {
 
 const DocsTableOfContents = ({ items }) => {
   const toTop = {
-    url: "",
+    // the top most div of content to scroll to 
+    url: "#docs-content",
     title: "↑ Top"
   }
 

--- a/src/css/docs/components/docs-page.css
+++ b/src/css/docs/components/docs-page.css
@@ -1,5 +1,6 @@
 html[is-docs-page],
 html[is-docs-page] body {
+  scroll-behavior: smooth;
   height: 100%;
   overscroll-behavior-y: none;
 }


### PR DESCRIPTION
removed navigate() function from reach/router library that was causing a delay and not accurately scrolling to the correct anchor. 
