### PR TITLE
updated cloudflare-brand-assets npm version to 4.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Cloudflare <github@cloudflare.com>",
   "dependencies": {
     "@adaptivelink/pops": "0.2.10",
-    "@cloudflare/cloudflare-brand-assets": "^4.7.6",
+    "@cloudflare/cloudflare-brand-assets": "^4.7.7",
     "@material-ui/core": "4.11.0",
     "@mdx-js/mdx": "1.6.6",
     "@mdx-js/react": "1.6.6",


### PR DESCRIPTION
updated cloudflare-brand-assets npm version to 4.7.7 in anticipation of 2 new icons: cache and client-ip-geolocation product 