### PR TITLE
MRK-13802 remove br from code block

### DIFF
--- a/src/components/mdx/code-block.js
+++ b/src/components/mdx/code-block.js
@@ -116,20 +116,14 @@ const CodeBlock = (props) => {
                     }
                   >
                     <span className="CodeBlock--row-indicator"></span>
-                    <span className="CodeBlock--row-content">
+                    <div className="CodeBlock--row-content">
                       {addNewlineToEmptyLine(line).map((token, key) => (
                         <span
                           key={key}
                           {...tokenProps(getTokenProps({ token, key }))}
                         />
                       ))}
-                      {/* Forced newline added to the markup here for each line */}
-                      {/* This doesn't add an additional newline to be shown but */}
-                      {/* makes copying  and pasting more consistent */}
-                      <span className="CodeBlock--token-plain">
-                        <br />
-                      </span>
-                    </span>
+                    </div>
                   </span>
                 ))}
               </span>


### PR DESCRIPTION
remove br from code block and make span to div so that each line of code takes up a new block when pasting code on firefox