### PR TITLE
Part 1 of updating to use new way of getting and displaying icons

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,10 +57,6 @@ products.forEach(name => {
   productIcons[name] = require(getProduct(name)).pathD
 })
 
-if (docsConfig.productLogoPathD && docsConfig.productIconKey) {
-  return Error("Set either `productLogoPathD` or `productIconKey` in docs-config.js, not both")
-}
-
 if (docsConfig.productIconKey) {
   docsConfig.productLogoPathD = productIcons[docsConfig.productIconKey]
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,7 +57,8 @@ products.forEach(name => {
   productIcons[name] = require(getProduct(name)).pathD
 })
 
-if (docsConfig.productIconKey) {
+// This is to support some cases when the pathD is directly added in the docs-config manually in the product instead of getting the icon from the cloudflare-brand-assets repo
+if (docsConfig.productIconKey && !docsConfig.productLogoPathD) {
   docsConfig.productLogoPathD = productIcons[docsConfig.productIconKey]
 }
 

--- a/src/components/docs-product-logo.js
+++ b/src/components/docs-product-logo.js
@@ -1,13 +1,22 @@
 import React from "react"
 import getCloudflareDocsConfig from "../utils/get-cloudflare-docs-config"
+import getUniqueReadableID from "../utils/get-unique-readable-id"
 import AccessibleSVG from "./accessible-svg"
 
-export default () => {
-  const { product, productLogoPathD }  = getCloudflareDocsConfig()
+const titleID = getUniqueReadableID("title")
 
-  return (
+export default () => {
+  const { product, productLogoPathD, productIconKey, logoSVGContent } = getCloudflareDocsConfig()
+
+  return logoSVGContent ? (
+    <span
+      id={titleID}
+      title={`Cloudflare ${productIconKey ? productIconKey : 'product'} logo`}
+      dangerouslySetInnerHTML={{ __html: logoSVGContent }}
+    />
+  ) : (
     <AccessibleSVG title={`Cloudflare ${product} logo`} viewBox="0 0 48 48">
-      <path d={productLogoPathD}/>
+      <path d={productLogoPathD} />
     </AccessibleSVG>
   )
 }

--- a/src/components/docs-product-logo.js
+++ b/src/components/docs-product-logo.js
@@ -1,16 +1,13 @@
 import React from "react"
 import getCloudflareDocsConfig from "../utils/get-cloudflare-docs-config"
-import getUniqueReadableID from "../utils/get-unique-readable-id"
 import AccessibleSVG from "./accessible-svg"
 
-const titleID = getUniqueReadableID("title")
 
 export default () => {
   const { product, productLogoPathD, productIconKey, logoSVGContent } = getCloudflareDocsConfig()
 
   return logoSVGContent ? (
     <span
-      id={titleID}
       title={`Cloudflare ${productIconKey ? productIconKey : 'product'} logo`}
       dangerouslySetInnerHTML={{ __html: logoSVGContent }}
     />

--- a/src/css/docs/components/docs-nav-logo-lockup.css
+++ b/src/css/docs/components/docs-nav-logo-lockup.css
@@ -16,6 +16,7 @@
   color: var(--orange);
   margin-right: var(--gap);
   flex-shrink: 0;
+  fill: var(--orange);
 }
 
 .DocsNavLogoLockup--text {

--- a/src/utils/get-cloudflare-docs-config.js
+++ b/src/utils/get-cloudflare-docs-config.js
@@ -19,6 +19,7 @@ export default () => {
               pathPrefix
               product
               productLogoPathD
+              # logoSVGContent
               contentRepo
               contentRepoFolder
               externalLinks {


### PR DESCRIPTION
Part 1: 
This makes sure that if there is no logoSVGPath then use the old the way of displaying icons on product pages so that it doesnt break the current developer docs code