### PR TITLE
remove google analytics and add gatsby plugin for google tag manager

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -156,5 +156,13 @@ module.exports = {
     // Consider enabling for PWA + offline functionality
     // https://gatsby.dev/offline
     // 'gatsby-plugin-offline',
+    {
+      resolve: "gatsby-plugin-google-tagmanager",
+      options: {
+        id: "GTM-PKQFGQB",
+        dataLayerName: "cfDataLayer",
+        selfHostedOrigin: "https://tr.www.cloudflare.com"
+      },
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "focus-visible-polyfill": "1.0.0",
     "gatsby": "2.24.7",
     "gatsby-image": "2.4.13",
+    "gatsby-plugin-google-tagmanager": "^2.3.10",
     "gatsby-plugin-layout": "1.3.10",
     "gatsby-plugin-manifest": "2.4.18",
     "gatsby-plugin-material-ui": "2.1.9",

--- a/src/html.js
+++ b/src/html.js
@@ -9,8 +9,6 @@ export default function HTML(props) {
         <meta httpEquiv="x-ua-compatible" content="ie=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         { props.headComponents }
-        <script type="text/javascript" src="https://developers.cloudflare.com/_cf/analytics.js" />
-        <script src="https://tr.www.cloudflare.com/gtm.js?id=GTM-PKQFGQB" />
       </head>
 
       <body { ...props.bodyAttributes }>


### PR DESCRIPTION
This PR:
- Remove google analytics code scripts from header
-  Use gatsby plugin google tag manager for tracking