### PR TITLE
fix fs browser error for new icon update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "cloudflare-docs-engine",
   "private": true,
+  "browser": {
+    "fs": false
+  },
   "description": "Cloudflare Workers documentation engine",
   "version": "0.1.5",
   "author": "Cloudflare <github@cloudflare.com>",


### PR DESCRIPTION
When merging part 1 of svg icon update, there was an error during wrangler build.
This will fix the error when code is merged and ready to be deployed in github actions