### PR TITLE
svg path color override

### DIFF
--- a/src/css/docs/components/docs-nav-logo-lockup.css
+++ b/src/css/docs/components/docs-nav-logo-lockup.css
@@ -19,6 +19,11 @@
   fill: var(--orange);
 }
 
+/* When svg paths have gradiants this will override to just orange */ 
+.DocsNavLogoLockup--logo path {
+  fill: var(--orange);
+}
+
 .DocsNavLogoLockup--text {
   font-size: var(--font-size, 1em);
   font-weight: 700;


### PR DESCRIPTION
Problem: On mobile the gradient color was present and not on desktop

Certain svg paths contain gradients this will ensure that there will be an override and it will be solid orange for the fill color