### PR TITLE
chore: MRK-14167 Add pcx-content-type metadata

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -58,6 +58,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
               slug
             }
             frontmatter {
+              pcx_content_type
               title
               type
               order
@@ -111,6 +112,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type Frontmatter {
+      pcx_content_type:String
       demo: String
       breadcrumbs: Boolean
       difficulty: String
@@ -140,7 +142,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       search: AlgoliaSearch
       externalLinks: [ExternalLinksType]
     }
-    
+
     type ExternalLinksType {
       title: String
       url: String
@@ -149,7 +151,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type AlgoliaOptions {
       facetFilters: String
     }
-    
+
     type AlgoliaSearch {
       indexName: String
       apiKey: String

--- a/src/components/docs-page.js
+++ b/src/components/docs-page.js
@@ -22,6 +22,7 @@ import DocsFooter from "./docs-footer"
 
 import getCloudflareDocsConfig from "../utils/get-cloudflare-docs-config"
 import getPageTitle from "../utils/get-page-title"
+import getPcxContentType from "../utils/get-pxc-content-type"
 import getPageType from "../utils/get-page-type"
 import getTableOfContents from "../utils/get-table-of-contents"
 import hasBreadcrumbs from "../utils/has-breadcrumbs"
@@ -29,35 +30,51 @@ import hasBreadcrumbs from "../utils/has-breadcrumbs"
 const DocsPage = ({ pageContext: page, children, location }) => {
   const title = getPageTitle(page, true)
   const pageType = getPageType(page)
+  const pcxContentType = getPcxContentType(page)
   const tableOfContents = getTableOfContents(page)
 
   const { search } = getCloudflareDocsConfig()
-  const enableSearch = search.apiKey && search.indexName && search.algoliaOptions
+  const enableSearch =
+    search.apiKey && search.indexName && search.algoliaOptions
   const disableSearchProps = enableSearch ? {} : { "search-disabled": "" }
 
   return (
     <>
-      <SEO title={title}/>
+      <SEO title={title} pcxContentType={pcxContentType} />
 
       <Helmet>
-        <html is-docs-page="" {...disableSearchProps}/>
-        <script data-source="docs" async defer src="https://feedback.developers.cloudflare.com/sdk.js"></script>
-        <link rel="preload" href="https://feedback.developers.cloudflare.com/sdk.css" as="style" onload="this.onload=null;this.rel='stylesheet'"/>
-        <noscript>{'<link rel="stylesheet" href="https://feedback.developers.cloudflare.com/sdk.css"/>'}</noscript>
+        <html is-docs-page="" {...disableSearchProps} />
+        <script
+          data-source="docs"
+          async
+          defer
+          src="https://feedback.developers.cloudflare.com/sdk.js"
+        ></script>
+        <link
+          rel="preload"
+          href="https://feedback.developers.cloudflare.com/sdk.css"
+          as="style"
+          onload="this.onload=null;this.rel='stylesheet'"
+        />
+        <noscript>
+          {
+            '<link rel="stylesheet" href="https://feedback.developers.cloudflare.com/sdk.css"/>'
+          }
+        </noscript>
       </Helmet>
 
-      <HandleMobilePageNavigations/>
-      <BrowserResizeTracking/>
-      <SmoothScrollHashChanges/>
+      <HandleMobilePageNavigations />
+      <BrowserResizeTracking />
+      <SmoothScrollHashChanges />
 
-      <SkipNavLink contentId="docs-content" className="SkipNavLink"/>
+      <SkipNavLink contentId="docs-content" className="SkipNavLink" />
 
       <div className="DocsPage">
-        <DocsMobileHeader/>
-        <DocsMobileTitleHeader/>
-        <div className="DocsMobileNavBackdrop"/>
-        <DocsSidebar/>
-        <DocsToolbar/>
+        <DocsMobileHeader />
+        <DocsMobileTitleHeader />
+        <div className="DocsMobileNavBackdrop" />
+        <DocsSidebar />
+        <DocsToolbar />
 
         <main className="DocsBody">
           {pageType === "document" && tableOfContents && (
@@ -65,26 +82,27 @@ const DocsPage = ({ pageContext: page, children, location }) => {
               <div className="DocsBody--sidebar-content-scroll-fade"></div>
               <div className="DocsBody--sidebar-content">
                 <nav>
-                  <DocsTableOfContents items={tableOfContents}/>
+                  <DocsTableOfContents items={tableOfContents} />
                 </nav>
               </div>
             </div>
           )}
 
-          <SkipNavContent id="docs-content"/>
+          <SkipNavContent id="docs-content" />
 
           <div className="DocsContent" page-type={pageType}>
             {hasBreadcrumbs(page) && (
-              <Breadcrumbs className="DocsContent--breadcrumbs" location={location}/>
+              <Breadcrumbs
+                className="DocsContent--breadcrumbs"
+                location={location}
+              />
             )}
 
-            <article className={docsMarkdownClassName()}>
-              {children}
-            </article>
+            <article className={docsMarkdownClassName()}>{children}</article>
           </div>
         </main>
 
-        <DocsFooter page={page}/>
+        <DocsFooter page={page} />
       </div>
     </>
   )

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ lang, title, description, meta }) {
+function SEO({ lang, title, description, meta, pcxContentType }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -29,29 +29,33 @@ function SEO({ lang, title, description, meta }) {
     "Docs",
     "Overview",
     "Welcome",
-    siteTitle
+    siteTitle,
   ].includes(pageTitle)
 
   title = isHomeTitle ? siteTitle : `${pageTitle} · ${siteTitle}`
 
   return (
     <Helmet>
-      <html lang={lang}/>
+      <html lang={lang} />
 
       <title>{title}</title>
 
-      <meta name="description" content={metaDescription}/>
+      <meta name="description" content={metaDescription} />
 
       <meta property="og:image" content={site.siteMetadata.image} />
-      <meta property="og:title" content={title}/>
-      <meta property="og:description" content={metaDescription}/>
-      <meta property="og:type" content="website"/>
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:type" content="website" />
 
-      <meta name="twitter:title" content={title}/>
-      <meta name="twitter:image" content="https://www.cloudflare.com/img/cf-twitter-card.png"/>
-      <meta name="twitter:description" content={metaDescription}/>
-      <meta name="twitter:creator" content={site.siteMetadata.author}/>
-      <meta name="twitter:card" content="summary_large_image"/>
+      <meta name="twitter:title" content={title} />
+      <meta
+        name="twitter:image"
+        content="https://www.cloudflare.com/img/cf-twitter-card.png"
+      />
+      <meta name="twitter:description" content={metaDescription} />
+      <meta name="twitter:creator" content={site.siteMetadata.author} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="pcx-content-type" content={pcxContentType} />
     </Helmet>
   )
 }
@@ -59,14 +63,15 @@ function SEO({ lang, title, description, meta }) {
 SEO.defaultProps = {
   lang: "en",
   description: "",
-  meta: []
+  meta: [],
 }
 
 SEO.propTypes = {
   lang: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
-  meta: PropTypes.arrayOf(PropTypes.object)
+  meta: PropTypes.arrayOf(PropTypes.object),
+  pcxContentType: PropTypes.string,
 }
 
 export default SEO

--- a/src/utils/get-pxc-content-type.js
+++ b/src/utils/get-pxc-content-type.js
@@ -1,0 +1,5 @@
+export default ({ frontmatter }) => {
+  if (!frontmatter) return "error"
+
+  return frontmatter.pcx_content_type || ""
+}


### PR DESCRIPTION
Adding a metadata to dev docs, then, we'd be able to get that info from the Coveo scraper and use it as facet categories (single facet, each page can only have a single value for content type).
