### PR TITLE
chore: MRK-14167 Change pcx field from snake_case to camelCase

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -112,7 +112,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type Frontmatter {
-      pcx_content_type:String
+      pcxContentType:String
       demo: String
       breadcrumbs: Boolean
       difficulty: String


### PR DESCRIPTION
#### Description
In the previous PR, I added a new field `pcx-content-type` which will be used by `Coveo scrapper`, in the schema definition however, I used snake case `pcx_content_type` instead of camelCase `pcxContentType`. 
That resulted in the following deprecation warning 

<img width="778" alt="warn" src="https://user-images.githubusercontent.com/5984570/151359869-dcc43bd2-f82e-4826-84b6-59aa4276b32a.png">

This PR fixes that. 💪🏽


