### PR TITLE
Hide external link icon when anchor contains an image

### DIFF
--- a/src/css/docs/components/docs-markdown.css
+++ b/src/css/docs/components/docs-markdown.css
@@ -63,6 +63,10 @@
   opacity: .7;
 }
 
+.DocsMarkdown--link:has(img) .DocsMarkdown--link-external-icon {
+  display: none;
+}
+
 .DocsMarkdown--link:focus .DocsMarkdown--link-external-icon {
   opacity: 1;
 }


### PR DESCRIPTION
<img width="763" alt="CleanShot 2023-05-06 at 13 26 39@2x" src="https://user-images.githubusercontent.com/1306747/236650246-097ba833-7c87-4f35-81f2-e2931e09eab3.png">
https://developers.cloudflare.com/workers/platform/deploy-button/